### PR TITLE
fix CamtParser::Misc.to_amount_in_cents for integer values

### DIFF
--- a/lib/camt_parser/misc.rb
+++ b/lib/camt_parser/misc.rb
@@ -4,7 +4,9 @@ module CamtParser
       def to_amount_in_cents(value)
         return nil if value == nil || value.strip == ''
 
-        value.gsub(/[,|\.](\d*)/) { $1.ljust(2, '0') }.to_i
+        dollars, cents = value.split(/,|\./)
+        cents ||= '0'
+        format('%s%s', dollars, cents.ljust(2, '0')).to_i
       end
 
       def to_amount(value)

--- a/spec/lib/camt_parser/misc_spec.rb
+++ b/spec/lib/camt_parser/misc_spec.rb
@@ -3,11 +3,13 @@ require 'spec_helper'
 describe CamtParser::Misc do
   let(:dot_value) { "30.12" }
   let(:comma_value) { "30,12" }
+  let(:integer_value) { "1" }
 
   context '#to_amount_in_cents' do
     specify { expect(described_class.to_amount_in_cents(dot_value)).to be_kind_of(Integer) }
     specify { expect(described_class.to_amount_in_cents(dot_value)).to eq(3012) }
     specify { expect(described_class.to_amount_in_cents(comma_value)).to eq(3012) }
+    specify { expect(described_class.to_amount_in_cents(integer_value)).to eq(100) }
     specify { expect(described_class.to_amount_in_cents('')).to eq(nil) }
     specify { expect(described_class.to_amount_in_cents(nil)).to eq(nil) }
   end
@@ -16,6 +18,7 @@ describe CamtParser::Misc do
     specify { expect(described_class.to_amount(dot_value)).to be_kind_of(BigDecimal) }
     specify { expect(described_class.to_amount(dot_value)).to eq(30.12) }
     specify { expect(described_class.to_amount(comma_value)).to eq(30.12) }
+    specify { expect(described_class.to_amount(integer_value)).to eq(1.0) }
     specify { expect(described_class.to_amount('')).to eq(nil) }
     specify { expect(described_class.to_amount(nil)).to eq(nil) }
   end


### PR DESCRIPTION
Hey there. First of all, thanks for open sourcing this gem :)

I stumbled upon an issue where camt transactions do not return the correct cent values for `CamtParser::Transaction#amount_in_cents` when the transaction amount is an "Integer" (e.g. `<Amt Ccy="CHF">1</Amt>`).

This PR adds support for "Integer" values to `CamtParser::MIsc.to_amount_in_cents`.