### PR TITLE
Accounts can have other IDs than IBAN

### DIFF
--- a/lib/camt_parser/general/account.rb
+++ b/lib/camt_parser/general/account.rb
@@ -8,6 +8,14 @@ module CamtParser
       @iban ||= @xml_data.xpath('Id/IBAN/text()').text
     end
 
+    def other_id
+      @other_id ||= @xml_data.xpath('Id/Othr/Id/text()').text
+    end
+
+    def account_number
+      !iban.nil? && !iban.empty? ? iban : other_id
+    end
+
     def bic
       @bic ||= @xml_data.xpath('Svcr/FinInstnId/BIC/text()').text
     end

--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,9 @@ camt.statements.each do |statement|
   statement.entries.each do |entry|
     # Access individual entries/bank transfers
     puts entry.amount
-    puts entry.debitor.iban
+    entry.transactions.each do |transaction|
+      puts transaction.debitor
+    end
   end
 end
 ```

--- a/spec/fixtures/053/valid_example_with_other_id.xml
+++ b/spec/fixtures/053/valid_example_with_other_id.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.053.001.02" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:iso:std:iso:20022:tech:xsd:camt.053.001.02 camt.053.001.02.xsd">
+
+<BkToCstmrStmt>
+  <GrpHdr>
+    <MsgId>053D2013-12-27T22:05:03.0N130000005</MsgId>
+    <CreDtTm>2013-12-27T22:04:52.0+01:00</CreDtTm>
+    <MsgPgntn>
+      <PgNb>1</PgNb>
+      <LastPgInd>true</LastPgInd>
+    </MsgPgntn>
+  </GrpHdr>
+  <Stmt>
+    <Id>0352C5320131227220503</Id>
+    <ElctrncSeqNb>130000005</ElctrncSeqNb>
+    <CreDtTm>2013-12-27T22:04:52.0+01:00</CreDtTm>
+    <Acct>
+      <Id>
+        <Othr>
+          <Id>ABCDE1234</Id>
+        </Othr>
+      </Id>
+      <Ccy>EUR</Ccy>
+      <Ownr>
+        <Nm>Testkonto Nummer 1</Nm>
+      </Ownr>
+      <Svcr>
+        <FinInstnId>
+          <BIC>GENODEF1PFK</BIC>
+          <Nm>VR-Bank Rottal-Inn eG</Nm>
+          <Othr>
+            <Id>DE 129267947</Id>
+            <Issr>UmsStId</Issr>
+          </Othr>
+        </FinInstnId>
+      </Svcr>
+    </Acct>
+  </Stmt>
+</BkToCstmrStmt>
+</Document>

--- a/spec/lib/camt_parser/general/account_spec.rb
+++ b/spec/lib/camt_parser/general/account_spec.rb
@@ -7,8 +7,15 @@ RSpec.describe CamtParser::Account do
   let(:account) { ex_stmt.account }
 
   specify { expect(account.iban).to eq("DE14740618130000033626") }
+  specify { expect(account.account_number).to eq("DE14740618130000033626") }
   specify { expect(account.bic).to eq("GENODEF1PFK") }
   specify { expect(account.bank_name).to eq("VR-Bank Rottal-Inn eG") }
   specify { expect(account.currency).to eq("EUR") }
-end
 
+  context 'with Other/Id as account_number' do
+    let(:camt) { CamtParser::File.parse('spec/fixtures/053/valid_example_with_other_id.xml') }
+
+    specify { expect(account.other_id).to eq("ABCDE1234") }
+    specify { expect(account.account_number).to eq("ABCDE1234") }
+  end
+end


### PR DESCRIPTION
Some accounts (like savings) have no IBAN but apparently some internal bank id that is stored in `Id/Othr/Id`. Added methods to read these too.