### PR TITLE
gemspec: Drop unused "executables" directive

### DIFF
--- a/camt_parser.gemspec
+++ b/camt_parser.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 
   spec.files         = Dir['lib/**/*.rb', 'lib/**/*.rake'] # Important!
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 


### PR DESCRIPTION
This gem exposes no executables.