### PR TITLE
microopt: Prefer #tr over #gsub

### DIFF
--- a/lib/camt_parser/misc.rb
+++ b/lib/camt_parser/misc.rb
@@ -13,7 +13,7 @@ module CamtParser
       def to_amount(value)
         return nil if value == nil || value.strip == ''
 
-        BigDecimal(value.gsub(',', '.'))
+        BigDecimal(value.tr(',', '.'))
       end
     end
   end


### PR DESCRIPTION
For a very small performance gain.