### PR TITLE
Add support for accounts with negative balance

### DIFF
--- a/lib/camt_parser/052/report.rb
+++ b/lib/camt_parser/052/report.rb
@@ -37,8 +37,9 @@ module CamtParser
         @opening_balance ||= begin
           bal = @xml_data.xpath('Bal/Tp//Cd[contains(text(), "PRCD")]').first.ancestors('Bal')
           date = bal.xpath('Dt/Dt/text()').text
+          credit = bal.xpath('CdtDbtInd/text()').text == 'CRDT'
           currency = bal.xpath('Amt').attribute('Ccy').value
-          CamtParser::AccountBalance.new bal.xpath('Amt/text()').text, currency, date, true
+          CamtParser::AccountBalance.new bal.xpath('Amt/text()').text, currency, date, credit
         end
       end
       alias_method :opening_or_intermediary_balance, :opening_balance
@@ -47,8 +48,9 @@ module CamtParser
         @closing_balance ||= begin
           bal = @xml_data.xpath('Bal/Tp//Cd[contains(text(), "CLBD")]').first.ancestors('Bal')
           date = bal.xpath('Dt/Dt/text()').text
+          credit = bal.xpath('CdtDbtInd/text()').text == 'CRDT'
           currency = bal.xpath('Amt').attribute('Ccy').value
-          CamtParser::AccountBalance.new bal.xpath('Amt/text()').text, currency, date, true
+          CamtParser::AccountBalance.new bal.xpath('Amt/text()').text, currency, date, credit
         end
       end
       alias_method :closing_or_intermediary_balance, :closing_balance

--- a/lib/camt_parser/053/statement.rb
+++ b/lib/camt_parser/053/statement.rb
@@ -41,18 +41,19 @@ module CamtParser
         @opening_balance ||= begin
           bal = @xml_data.xpath('Bal/Tp//Cd[contains(text(), "OPBD") or contains(text(), "PRCD")]').first.ancestors('Bal')
           date = bal.xpath('Dt/Dt/text()').text
+          credit = bal.xpath('CdtDbtInd/text()').text == 'CRDT'
           currency = bal.xpath('Amt').attribute('Ccy').value
-          AccountBalance.new bal.xpath('Amt/text()').text, currency, date, true
+          AccountBalance.new bal.xpath('Amt/text()').text, currency, date, credit
         end
       end
-      alias_method :opening_or_intermediary_balance, :opening_balance
 
       def closing_balance
         @closing_balance ||= begin
           bal = @xml_data.xpath('Bal/Tp//Cd[contains(text(), "CLBD")]').first.ancestors('Bal')
           date = bal.xpath('Dt/Dt/text()').text
+          credit = bal.xpath('CdtDbtInd/text()').text == 'CRDT'
           currency = bal.xpath('Amt').attribute('Ccy').value
-          AccountBalance.new bal.xpath('Amt/text()').text, currency, date, true
+          AccountBalance.new bal.xpath('Amt/text()').text, currency, date, credit
         end
       end
       alias_method :closing_or_intermediary_balance, :closing_balance

--- a/lib/camt_parser/general/account_balance.rb
+++ b/lib/camt_parser/general/account_balance.rb
@@ -32,6 +32,10 @@ module CamtParser
       CamtParser::Misc.to_amount_in_cents(@amount)
     end
 
+    def signed_amount
+      amount * sign
+    end
+
     def to_h
       {
         'amount' => amount,

--- a/spec/fixtures/053/valid_example_with_debit.xml
+++ b/spec/fixtures/053/valid_example_with_debit.xml
@@ -1,0 +1,368 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.053.001.02" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:iso:std:iso:20022:tech:xsd:camt.053.001.02 camt.053.001.02.xsd">
+
+<BkToCstmrStmt>
+  <GrpHdr>
+    <MsgId>053D2013-12-27T22:05:03.0N130000005</MsgId>
+    <CreDtTm>2013-12-27T22:04:52.0+01:00</CreDtTm>
+    <MsgPgntn>
+      <PgNb>1</PgNb>
+      <LastPgInd>true</LastPgInd>
+    </MsgPgntn>
+  </GrpHdr>
+  <Stmt>
+    <Id>0352C5320131227220503</Id>
+    <ElctrncSeqNb>130000005</ElctrncSeqNb>
+    <CreDtTm>2013-12-27T22:04:52.0+01:00</CreDtTm>
+    <Acct>
+      <Id>
+        <IBAN>DE14740618130000033626</IBAN>
+      </Id>
+      <Ccy>EUR</Ccy>
+      <Ownr>
+        <Nm>Testkonto Nummer 1</Nm>
+      </Ownr>
+      <Svcr>
+        <FinInstnId>
+          <BIC>GENODEF1PFK</BIC>
+          <Nm>VR-Bank Rottal-Inn eG</Nm>
+          <Othr>
+            <Id>DE 129267947</Id>
+            <Issr>UmsStId</Issr>
+          </Othr>
+        </FinInstnId>
+      </Svcr>
+    </Acct>
+    <Bal>
+      <Tp>
+        <CdOrPrtry>
+          <Cd>PRCD</Cd>
+        </CdOrPrtry>
+      </Tp>
+      <Amt Ccy="EUR">33.06</Amt>
+      <CdtDbtInd>DBIT</CdtDbtInd>
+      <Dt>
+        <Dt>2013-12-27</Dt>
+      </Dt>
+    </Bal>
+    <Bal>
+      <Tp>
+        <CdOrPrtry>
+          <Cd>CLBD</Cd>
+        </CdOrPrtry>
+      </Tp>
+      <Amt Ccy="EUR">23.06</Amt>
+      <CdtDbtInd>CRDT</CdtDbtInd>
+      <Dt>
+        <Dt>2013-12-27</Dt>
+      </Dt>
+    </Bal>
+    <Ntry>
+      <Amt Ccy="EUR">2.00</Amt>
+      <CdtDbtInd>DBIT</CdtDbtInd>
+      <Sts>BOOK</Sts>
+      <BookgDt>
+        <Dt>2013-12-27</Dt>
+      </BookgDt>
+      <ValDt>
+        <Dt>2013-12-27</Dt>
+      </ValDt>
+      <AcctSvcrRef>2013122710583450000</AcctSvcrRef>
+      <BkTxCd/>
+      <NtryDtls>
+        <TxDtls>
+          <Refs>
+            <AcctSvcrRef>BankReference</AcctSvcrRef>
+            <EndToEndId>EndToEndReference</EndToEndId>
+            <MndtId>MandateReference</MndtId>
+            <PmtInfId>PaymentIdentification</PmtInfId>
+            <TxId>UniqueTransactionId</TxId>
+          </Refs>
+          <AddtlTxInf>AdditionalTransactionInformation</AddtlTxInf>
+          <BkTxCd>
+            <Prtry>
+              <Cd>NTRF+020</Cd>
+              <Issr>ZKA</Issr>
+            </Prtry>
+          </BkTxCd>
+          <RltdPties>
+            <Dbtr>
+              <Nm>Wayne Enterprises</Nm>
+            </Dbtr>
+            <DbtrAcct>
+              <Id>
+                <IBAN>DE24302201900609832118</IBAN>
+              </Id>
+            </DbtrAcct>
+            <Cdtr>
+              <Id>
+                <PrvtId>
+                  <Othr>
+                    <Id>CreditorIdentifier</Id>
+                  </Othr>
+                </PrvtId>
+              </Id>
+              <Nm>Testkonto Nummer 2</Nm>
+              <PstlAdr>
+                <AdrLine>Berlin</AdrLine>
+                <AdrLine>Infinite Loop 2</AdrLine>
+                <AdrLine>12345</AdrLine>
+              </PstlAdr>
+            </Cdtr>
+            <CdtrAcct>
+              <Id>
+                <IBAN>DE09300606010012345671</IBAN>
+              </Id>
+              <Tp>
+                <Cd>CACC</Cd>
+              </Tp>
+            </CdtrAcct>
+          </RltdPties>
+          <RltdAgts>
+              <DbtrAgt>
+                <FinInstnId>
+                  <BIC>DAAEDEDDXXX</BIC>
+                  <ClrSysMmbId>
+                    <ClrSysId>
+                      <Cd>ABCDEF</Cd>
+                    </ClrSysId>
+                    <MmbId>1232344234234</MmbId>
+                  </ClrSysMmbId>
+                </FinInstnId>
+              </DbtrAgt>
+              <CdtrAgt>
+                <FinInstnId>
+                  <BIC>DAAEDEDDXXX</BIC>
+                  <ClrSysMmbId>
+                    <ClrSysId>
+                      <Cd>ABCDEF</Cd>
+                    </ClrSysId>
+                    <MmbId>123456789</MmbId>
+                  </ClrSysMmbId>
+                  <Nm>Bank</Nm>
+                  <PstlAdr>
+                    <AdrLine>Infinite Loop 1</AdrLine>
+                    <AdrLine>Berlin</AdrLine>
+                  </PstlAdr>
+                </FinInstnId>
+              </CdtrAgt>
+            </RltdAgts>
+          <RmtInf>
+            <Ustrd>TEST BERWEISUNG MITTELS BLZUND KONTONUMMER - DTA</Ustrd>
+          </RmtInf>
+        </TxDtls>
+      </NtryDtls>
+      <AddtlNtryInf>Überweisungs-Gutschrift; GVC: SEPA Credit Transfer (Einzelbuchung-Haben)</AddtlNtryInf>
+    </Ntry>
+    <Ntry>
+      <Amt Ccy="EUR">3.00</Amt>
+      <CdtDbtInd>DBIT</CdtDbtInd>
+      <Sts>BOOK</Sts>
+      <BookgDt>
+        <Dt>2013-12-27</Dt>
+      </BookgDt>
+      <ValDt>
+        <Dt>2013-12-27</Dt>
+      </ValDt>
+      <AcctSvcrRef>2013122710583600000</AcctSvcrRef>
+      <BkTxCd/>
+      <NtryDtls>
+        <TxDtls>
+          <Refs>
+            <MsgId>CCTI/VRNWSW/b044f24cddb92a502b8a1b5</MsgId>
+            <EndToEndId>NOTPROVIDED</EndToEndId>
+          </Refs>
+          <BkTxCd>
+            <Prtry>
+              <Cd>NMSC+201</Cd>
+              <Issr>ZKA</Issr>
+            </Prtry>
+          </BkTxCd>
+          <RltdPties>
+            <Dbtr>
+              <Nm>Testkonto Nummer 1</Nm>
+            </Dbtr>
+            <DbtrAcct>
+              <Id>
+                <IBAN>DE14740618130000033626</IBAN>
+              </Id>
+            </DbtrAcct>
+            <UltmtDbtr>
+              <Nm>keine Information vorhanden</Nm>
+            </UltmtDbtr>
+            <Cdtr>
+              <Nm>Testkonto Nummer 2</Nm>
+            </Cdtr>
+            <CdtrAcct>
+              <Id>
+                <IBAN>DE58740618130100033626</IBAN>
+              </Id>
+            </CdtrAcct>
+            <UltmtCdtr>
+              <Nm>keine Information vorhanden</Nm>
+            </UltmtCdtr>
+          </RltdPties>
+          <RltdAgts>
+            <CdtrAgt>
+              <FinInstnId>
+                <BIC>GENODEF1PFK</BIC>
+              </FinInstnId>
+            </CdtrAgt>
+          </RltdAgts>
+          <RmtInf>
+            <Ustrd>Test+berweisung mit BIC und IBAN SEPA IBAN: DE58740618130100033626 BIC: GENODEF1PFK</Ustrd>
+          </RmtInf>
+        </TxDtls>
+      </NtryDtls>
+    </Ntry>
+    <Ntry>
+      <Amt Ccy="EUR">1.00</Amt>
+      <CdtDbtInd>CRDT</CdtDbtInd>
+      <Sts>BOOK</Sts>
+      <BookgDt>
+        <Dt>2013-12-27</Dt>
+      </BookgDt>
+      <ValDt>
+        <Dt>2013-12-27</Dt>
+      </ValDt>
+      <AcctSvcrRef>2013122711085260000</AcctSvcrRef>
+      <BkTxCd/>
+      <NtryDtls>
+        <TxDtls>
+          <BkTxCd>
+            <Prtry>
+              <Cd>NMSC+051</Cd>
+              <Issr>ZKA</Issr>
+            </Prtry>
+          </BkTxCd>
+          <RltdPties>
+            <Dbtr>
+              <Nm>Testkonto Nummer 2</Nm>
+            </Dbtr>
+            <DbtrAcct>
+              <Id>
+                <Othr>
+                  <Id>  740618130100033626</Id>
+                  <SchmeNm>
+                    <Cd>BBAN</Cd>
+                  </SchmeNm>
+                </Othr>
+              </Id>
+            </DbtrAcct>
+          </RltdPties>
+          <RmtInf>
+            <Ustrd>R CKBUCHUNG</Ustrd>
+          </RmtInf>
+        </TxDtls>
+      </NtryDtls>
+    </Ntry>
+    <Ntry>
+      <Amt Ccy="EUR">6.00</Amt>
+      <CdtDbtInd>DBIT</CdtDbtInd>
+      <Sts>BOOK</Sts>
+      <BookgDt>
+        <Dt>2013-12-27</Dt>
+      </BookgDt>
+      <ValDt>
+        <Dt>2013-12-27</Dt>
+      </ValDt>
+      <AcctSvcrRef>2013122711513230000</AcctSvcrRef>
+      <BkTxCd/>
+      <NtryDtls>
+        <Btch>
+          <PmtInfId>STZV-PmInf27122013-11:02-2</PmtInfId>
+          <NbOfTxs>2</NbOfTxs>
+        </Btch>
+        <TxDtls>
+          <Refs>
+            <MsgId>STZV-Msg27122013-11:02</MsgId>
+            <EndToEndId>STZV-EtE27122013-11:02-1</EndToEndId>
+          </Refs>
+          <AmtDtls>
+            <TxAmt>
+              <Amt Ccy="EUR">3.50</Amt>
+            </TxAmt>
+          </AmtDtls>
+          <BkTxCd>
+            <Prtry>
+              <Cd>NMSC+201</Cd>
+              <Issr>ZKA</Issr>
+            </Prtry>
+          </BkTxCd>
+          <RltdPties>
+            <Dbtr>
+              <Nm>Testkonto Nummer 2</Nm>
+            </Dbtr>
+            <DbtrAcct>
+              <Id>
+                <IBAN>DE58740618130100033626</IBAN>
+              </Id>
+            </DbtrAcct>
+            <UltmtDbtr>
+              <Nm>keine Information vorhanden</Nm>
+            </UltmtDbtr>
+            <Cdtr>
+              <Nm>Testkonto Nummer 1</Nm>
+            </Cdtr>
+            <CdtrAcct>
+              <Id>
+                <IBAN>DE14740618130000033626</IBAN>
+              </Id>
+            </CdtrAcct>
+            <UltmtCdtr>
+              <Nm>Testkonto</Nm>
+            </UltmtCdtr>
+          </RltdPties>
+          <RmtInf>
+            <Ustrd>Sammelueberwseisung 2. Zahlung   TAN:283044   </Ustrd>
+          </RmtInf>
+        </TxDtls>
+        <TxDtls>
+          <Refs>
+            <MsgId>STZV-Msg27122013-11:02</MsgId>
+            <EndToEndId>STZV-EtE27122013-11:02-2</EndToEndId>
+          </Refs>
+          <AmtDtls>
+            <TxAmt>
+              <Amt Ccy="EUR">2.50</Amt>
+            </TxAmt>
+          </AmtDtls>
+          <BkTxCd>
+            <Prtry>
+              <Cd>NMSC+201</Cd>
+              <Issr>ZKA</Issr>
+            </Prtry>
+          </BkTxCd>
+          <RltdPties>
+            <Dbtr>
+              <Nm>Testkonto Nummer 2</Nm>
+            </Dbtr>
+            <DbtrAcct>
+              <Id>
+                <IBAN>DE58740618130100033626</IBAN>
+              </Id>
+            </DbtrAcct>
+            <UltmtDbtr>
+              <Nm>keine Information vorhanden</Nm>
+            </UltmtDbtr>
+            <Cdtr>
+              <Nm>Testkonto Nummer 1</Nm>
+            </Cdtr>
+            <CdtrAcct>
+              <Id>
+                <IBAN>DE14740618130000033626</IBAN>
+              </Id>
+            </CdtrAcct>
+            <UltmtCdtr>
+              <Nm>Testkonto</Nm>
+            </UltmtCdtr>
+          </RltdPties>
+          <RmtInf>
+            <Ustrd>Sammelueberweisung 1. Zahlung   TAN:283044   </Ustrd>
+          </RmtInf>
+        </TxDtls>
+      </NtryDtls>
+    </Ntry>
+  </Stmt>
+</BkToCstmrStmt>
+</Document>

--- a/spec/lib/camt_parser/general/account_balance_spec.rb
+++ b/spec/lib/camt_parser/general/account_balance_spec.rb
@@ -12,9 +12,30 @@ RSpec.describe CamtParser::AccountBalance do
   specify { expect(subject.credit?).to be_truthy }
   specify { expect(subject.amount).to eq BigDecimal("33.06") }
   specify { expect(subject.amount_in_cents).to eq(3306) }
+  specify { expect(subject.signed_amount).to eq BigDecimal("33.06") }
   specify { expect(subject.to_h).to eq({
     'amount'          => BigDecimal('33.06'),
     'amount_in_cents' => 3306,
     'sign'            => 1
   }) }
+
+  context 'debit' do
+    let(:camt)       { CamtParser::File.parse('spec/fixtures/053/valid_example_with_debit.xml') }
+    let(:statements) { camt.statements }
+    let(:ex_stmt)    { camt.statements[0] }
+    subject { ex_stmt.opening_balance }
+
+    specify { expect(subject.currency).to eq "EUR" }
+    specify { expect(subject.date).to eq Date.new(2013, 12, 27) }
+    specify { expect(subject.sign).to eq -1 }
+    specify { expect(subject.credit?).to be_falsey }
+    specify { expect(subject.amount).to eq BigDecimal("33.06") }
+    specify { expect(subject.amount_in_cents).to eq(3306) }
+    specify { expect(subject.signed_amount).to eq BigDecimal("-33.06") }
+    specify { expect(subject.to_h).to eq({
+                                           'amount'          => BigDecimal('33.06'),
+                                           'amount_in_cents' => 3306,
+                                           'sign'            => -1
+                                         }) }
+  end
 end


### PR DESCRIPTION
We encountered statements from accounts with a negative balance which are not really covered by camt_parser at the moment. This adds support for those statements.