### PR TITLE
Update ruby version matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,10 @@ jobs:
     strategy:
       matrix:
         ruby-version:
+          - 3.2
           - 3.1
           - "3.0"
           - 2.7
-          - 2.6
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,6 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-          - 3.2
           - 3.1
           - "3.0"
           - 2.7

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    camt_parser (2.13.0)
+    camt_parser (2.14.0)
       nokogiri
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GEM
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     racc (1.6.1)
-    rake (13.0.1)
+    rake (13.0.6)
     rspec (3.3.0)
       rspec-core (~> 3.3.0)
       rspec-expectations (~> 3.3.0)
@@ -35,8 +35,8 @@ PLATFORMS
 DEPENDENCIES
   builder (~> 3.2.2)
   camt_parser!
-  rake (~> 13.0.1)
+  rake (~> 13.0.6)
   rspec (~> 3.3.0)
 
 BUNDLED WITH
-   1.17.3
+   2.4.2

--- a/camt_parser.gemspec
+++ b/camt_parser.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "rake",                  "~> 13.0.1"
+  spec.add_development_dependency "rake",                  "~> 13.0.6"
   spec.add_development_dependency "rspec",                 "~> 3.3.0"
   spec.add_development_dependency "builder",               "~> 3.2.2"
 

--- a/lib/camt_parser/version.rb
+++ b/lib/camt_parser/version.rb
@@ -1,3 +1,3 @@
 module CamtParser
-  VERSION = '2.13.0'.freeze
+  VERSION = '2.14.0'.freeze
 end


### PR DESCRIPTION
As ruby 3.2 was released a few weeks ago and ruby 2.6 is not actually officially supported anymore, this updates the dependency matrix

Additionally, rake and bundler wer updated