### PR TITLE
Add YARD docblocks

### DIFF
--- a/lib/camt_parser/054/notification.rb
+++ b/lib/camt_parser/054/notification.rb
@@ -5,34 +5,42 @@ module CamtParser
         @xml_data = xml_data
       end
 
+      # @return [String]
       def identification
         @identification ||= @xml_data.xpath('Id/text()').text
       end
 
+      # @return [Time]
       def generation_date
         @generation_date ||= Time.parse(@xml_data.xpath('CreDtTm/text()').text)
       end
 
+      # @return [Time, nil]
       def from_date_time
         @from_date_time ||= (x = @xml_data.xpath('FrToDt/FrDtTm')).empty? ? nil : Time.parse(x.first.content)
       end
 
+      # @return [Time, nil]
       def to_date_time
         @to_date_time ||= (x = @xml_data.xpath('FrToDt/ToDtTm')).empty? ? nil : Time.parse(x.first.content)
       end
 
+      # @return [Account]
       def account
         @account ||= Account.new(@xml_data.xpath('Acct').first)
       end
 
+      # @return [Array<Entry>]
       def entries
         @entries ||= @xml_data.xpath('Ntry').map{ |x| Entry.new(x) }
       end
 
+      # @return [String]
       def source
         @xml_data.to_s
       end
 
+      # @return [CamtParser::Format054::Notification]
       def self.parse(xml)
         self.new Nokogiri::XML(xml).xpath('Ntfctn')
       end

--- a/lib/camt_parser/general/account.rb
+++ b/lib/camt_parser/general/account.rb
@@ -4,26 +4,32 @@ module CamtParser
       @xml_data = xml_data
     end
 
+    # @return [String]
     def iban
       @iban ||= @xml_data.xpath('Id/IBAN/text()').text
     end
 
+    # @return [String]
     def other_id
       @other_id ||= @xml_data.xpath('Id/Othr/Id/text()').text
     end
 
+    # @return [String]
     def account_number
       !iban.nil? && !iban.empty? ? iban : other_id
     end
 
+    # @return [String]
     def bic
       @bic ||= @xml_data.xpath('Svcr/FinInstnId/BIC/text()').text
     end
 
+    # @return [String]
     def bank_name
       @bank_name ||= @xml_data.xpath('Svcr/FinInstnId/Nm/text()').text
     end
 
+    # @return [String]
     def currency
       @currency ||= @xml_data.xpath('Ccy/text()').text
     end

--- a/lib/camt_parser/general/account_balance.rb
+++ b/lib/camt_parser/general/account_balance.rb
@@ -1,6 +1,10 @@
 module CamtParser
   class AccountBalance
 
+    # @param amount [String]
+    # @param currency [String]
+    # @param date [String]
+    # @param  credit [Boolean]
     def initialize(amount, currency, date, credit = false)
       @amount = amount
       @currency = currency
@@ -8,34 +12,42 @@ module CamtParser
       @credit = credit
     end
 
+    # @return [String]
     def currency
       @currency
     end
 
+    # @return [Date]
     def date
       Date.parse @date
     end
 
+    # @return [Integer] either 1 or -1
     def sign
       credit? ? 1 : -1
     end
 
+    # @return [Boolean]
     def credit?
       @credit
     end
 
+    # @return [BigDecimal]
     def amount
       CamtParser::Misc.to_amount(@amount)
     end
 
+    # @return [Integer]
     def amount_in_cents
       CamtParser::Misc.to_amount_in_cents(@amount)
     end
 
+    # @return [BigDecimal]
     def signed_amount
       amount * sign
     end
 
+    # @return [Hash{String => BigDecimal, Integer}]
     def to_h
       {
         'amount' => amount,

--- a/lib/camt_parser/general/entry.rb
+++ b/lib/camt_parser/general/entry.rb
@@ -13,59 +13,72 @@ module CamtParser
       CamtParser::Misc.to_amount_in_cents(@amount)
     end
 
+    # @return [String]
     def currency
       @currency ||= @xml_data.xpath('Amt/@Ccy').text
     end
 
+    # @return [Boolean]
     def debit
       @debit ||= @xml_data.xpath('CdtDbtInd/text()').text.upcase == 'DBIT'
     end
 
+    # @return [Date]
     def value_date
       @value_date ||= Date.parse(@xml_data.xpath('ValDt/Dt/text()').text)
     end
 
+    # @return [Date]
     def booking_date
       @booking_date ||= Date.parse(@xml_data.xpath('BookgDt/Dt/text()').text)
     end
 
+    # @return [String]
     def bank_reference # May be missing
       @bank_reference ||= @xml_data.xpath('AcctSvcrRef/text()').text
     end
 
+    # @return [Array<CamtParser::Transaction>]
     def transactions
       @transactions ||= parse_transactions
     end
 
+    # @return [Boolean]
     def credit?
       !debit
     end
 
+    # @return [Boolean]
     def debit?
       debit
     end
 
+    # @return [Integer] either 1 or -1
     def sign
       credit? ? 1 : -1
     end
 
+    # @return [Boolean]
     def reversal?
       @reversal ||= @xml_data.xpath('RvslInd/text()').text.downcase == 'true'
     end
 
+    # @return [Boolean]
     def booked?
       @booked ||= @xml_data.xpath('Sts/text()').text.upcase == 'BOOK'
     end
 
+    # @return [String]
     def additional_information
       @additional_information ||= @xml_data.xpath('AddtlNtryInf/text()').text
     end
     alias_method :description, :additional_information
 
+    # @return [CamtParser::Charges]
     def charges
       @charges ||= CamtParser::Charges.new(@xml_data.xpath('Chrgs'))
     end
-    
+    # @return [CamtParser::BatchDetail, nil]
     def batch_detail
       @batch_detail ||= @xml_data.xpath('NtryDtls/Btch').empty? ? nil : CamtParser::BatchDetail.new(@xml_data.xpath('NtryDtls/Btch'))
     end  

--- a/lib/camt_parser/misc.rb
+++ b/lib/camt_parser/misc.rb
@@ -1,6 +1,9 @@
 module CamtParser
   class Misc
     class << self
+
+      # @param value [nil, String]
+      # @return [Integer, nil]
       def to_amount_in_cents(value)
         return nil if value == nil || value.strip == ''
 
@@ -10,6 +13,8 @@ module CamtParser
         format('%s%s', dollars, cents.ljust(2, '0')).to_i
       end
 
+      # @param value [nil, String]
+      # @return [BigDecimal, nil]
       def to_amount(value)
         return nil if value == nil || value.strip == ''
 


### PR DESCRIPTION
This begins this annotation, in a single place, as a start.

EDIT: Well, a few places.

I needed some of these, to explore the library in an easier way.

What it looks like before this change:
https://www.rubydoc.info/gems/camt_parser/CamtParser/Account

<img width="569" alt="bild" src="https://user-images.githubusercontent.com/211/235067024-e82e7eb7-db6b-4526-9feb-78ac017d9a0e.png">

What it looks like after this tiny change (locally):

<img width="589" alt="bild" src="https://user-images.githubusercontent.com/211/235067250-c7e8b6ad-72d6-45f8-acf0-ccfd532bad66.png">
