### PR TITLE
Add support for camt.053.001.08

### DIFF
--- a/lib/camt_parser/general/account.rb
+++ b/lib/camt_parser/general/account.rb
@@ -17,7 +17,13 @@ module CamtParser
     end
 
     def bic
-      @bic ||= @xml_data.xpath('Svcr/FinInstnId/BIC/text()').text
+      @bic ||= @xml_data.xpath('Svcr/FinInstnId/BIC/text()').text.then do |bic|
+        if bic.empty?
+          @xml_data.xpath('Svcr/FinInstnId/BICFI/text()').text
+        else
+          bic
+        end
+      end
     end
 
     def bank_name

--- a/lib/camt_parser/general/account.rb
+++ b/lib/camt_parser/general/account.rb
@@ -17,13 +17,10 @@ module CamtParser
     end
 
     def bic
-      @bic ||= @xml_data.xpath('Svcr/FinInstnId/BIC/text()').text.then do |bic|
-        if bic.empty?
-          @xml_data.xpath('Svcr/FinInstnId/BICFI/text()').text
-        else
-          bic
-        end
-      end
+      @bic ||= [
+        @xml_data.xpath('Svcr/FinInstnId/BIC/text()').text,
+        @xml_data.xpath('Svcr/FinInstnId/BICFI/text()').text,
+      ].reject(&:empty?).first.to_s
     end
 
     def bank_name

--- a/lib/camt_parser/general/creditor.rb
+++ b/lib/camt_parser/general/creditor.rb
@@ -18,7 +18,7 @@ module CamtParser
     def bic
       @bic ||= [
         @xml_data.xpath('RltdAgts/CdtrAgt/FinInstnId/BIC/text()').text,
-        @xml_data.xpath('RltdAgts/DbtrAgt/FinInstnId/BICFI/text()').text,
+        @xml_data.xpath('RltdAgts/CdtrAgt/FinInstnId/BICFI/text()').text,
       ].reject(&:empty?).first.to_s
     end
 

--- a/lib/camt_parser/general/creditor.rb
+++ b/lib/camt_parser/general/creditor.rb
@@ -5,13 +5,10 @@ module CamtParser
     end
 
     def name
-      @name ||= @xml_data.xpath('RltdPties/Cdtr/Nm/text()').text.then do |name|
-        if name.empty?
-          @xml_data.xpath('RltdPties/Cdtr/Pty/Nm/text()').text
-        else
-          name
-        end
-      end
+      @name ||= [
+        @xml_data.xpath('RltdPties/Cdtr/Nm/text()').text,
+        @xml_data.xpath('RltdPties/Cdtr/Pty/Nm/text()').text,
+      ].reject(&:empty?).first.to_s
     end
 
     def iban
@@ -19,13 +16,10 @@ module CamtParser
     end
 
     def bic
-      @bic ||= @xml_data.xpath('RltdAgts/CdtrAgt/FinInstnId/BIC/text()').text.then do |bic|
-        if bic.empty?
-          @xml_data.xpath('RltdAgts/DbtrAgt/FinInstnId/BICFI/text()').text
-        else
-          bic
-        end
-      end
+      @bic ||= [
+        @xml_data.xpath('RltdAgts/CdtrAgt/FinInstnId/BIC/text()').text,
+        @xml_data.xpath('RltdAgts/DbtrAgt/FinInstnId/BICFI/text()').text,
+      ].reject(&:empty?).first.to_s
     end
 
     def bank_name

--- a/lib/camt_parser/general/creditor.rb
+++ b/lib/camt_parser/general/creditor.rb
@@ -5,7 +5,13 @@ module CamtParser
     end
 
     def name
-      @name ||= @xml_data.xpath('RltdPties/Cdtr/Nm/text()').text
+      @name ||= @xml_data.xpath('RltdPties/Cdtr/Nm/text()').text.then do |name|
+        if name.empty?
+          @xml_data.xpath('RltdPties/Cdtr/Pty/Nm/text()').text
+        else
+          name
+        end
+      end
     end
 
     def iban

--- a/lib/camt_parser/general/creditor.rb
+++ b/lib/camt_parser/general/creditor.rb
@@ -19,7 +19,13 @@ module CamtParser
     end
 
     def bic
-      @bic ||= @xml_data.xpath('RltdAgts/CdtrAgt/FinInstnId/BIC/text()').text
+      @bic ||= @xml_data.xpath('RltdAgts/CdtrAgt/FinInstnId/BIC/text()').text.then do |bic|
+        if bic.empty?
+          @xml_data.xpath('RltdAgts/DbtrAgt/FinInstnId/BICFI/text()').text
+        else
+          bic
+        end
+      end
     end
 
     def bank_name

--- a/lib/camt_parser/general/debitor.rb
+++ b/lib/camt_parser/general/debitor.rb
@@ -5,7 +5,13 @@ module CamtParser
     end
 
     def name
-      @name ||= @xml_data.xpath('RltdPties/Dbtr/Nm/text()').text
+      @name ||= @xml_data.xpath('RltdPties/Dbtr/Nm/text()').text.then do |name|
+        if name.empty?
+          @xml_data.xpath('RltdPties/Dbtr/Pty/Nm/text()').text
+        else
+          name
+        end
+      end
     end
 
     def iban

--- a/lib/camt_parser/general/debitor.rb
+++ b/lib/camt_parser/general/debitor.rb
@@ -19,7 +19,13 @@ module CamtParser
     end
 
     def bic
-      @bic ||= @xml_data.xpath('RltdAgts/DbtrAgt/FinInstnId/BIC/text()').text
+      @bic ||= @xml_data.xpath('RltdAgts/DbtrAgt/FinInstnId/BIC/text()').text.then do |bic|
+        if bic.empty?
+          @xml_data.xpath('RltdAgts/DbtrAgt/FinInstnId/BICFI/text()').text
+        else
+          bic
+        end
+      end
     end
 
     def bank_name

--- a/lib/camt_parser/general/debitor.rb
+++ b/lib/camt_parser/general/debitor.rb
@@ -5,13 +5,10 @@ module CamtParser
     end
 
     def name
-      @name ||= @xml_data.xpath('RltdPties/Dbtr/Nm/text()').text.then do |name|
-        if name.empty?
-          @xml_data.xpath('RltdPties/Dbtr/Pty/Nm/text()').text
-        else
-          name
-        end
-      end
+      @name ||= [
+        @xml_data.xpath('RltdPties/Dbtr/Nm/text()').text,
+        @xml_data.xpath('RltdPties/Dbtr/Pty/Nm/text()').text,
+      ].reject(&:empty?).first.to_s
     end
 
     def iban
@@ -19,13 +16,10 @@ module CamtParser
     end
 
     def bic
-      @bic ||= @xml_data.xpath('RltdAgts/DbtrAgt/FinInstnId/BIC/text()').text.then do |bic|
-        if bic.empty?
-          @xml_data.xpath('RltdAgts/DbtrAgt/FinInstnId/BICFI/text()').text
-        else
-          bic
-        end
-      end
+      @bic ||= [
+        @xml_data.xpath('RltdAgts/DbtrAgt/FinInstnId/BIC/text()').text,
+        @xml_data.xpath('RltdAgts/DbtrAgt/FinInstnId/BICFI/text()').text,
+      ].reject(&:empty?).first.to_s
     end
 
     def bank_name

--- a/lib/camt_parser/register.rb
+++ b/lib/camt_parser/register.rb
@@ -7,6 +7,7 @@ CamtParser::Xml.register('urn:iso:std:iso:20022:tech:xsd:camt.052.001.02', :camt
 ## CAMT053
 CamtParser::Xml.register('urn:iso:std:iso:20022:tech:xsd:camt.053.001.02', :camt053)
 CamtParser::Xml.register('urn:iso:std:iso:20022:tech:xsd:camt.053.001.04', :camt053)
+CamtParser::Xml.register('urn:iso:std:iso:20022:tech:xsd:camt.053.001.08', :camt053)
 
 ## CAMT054
 CamtParser::Xml.register('urn:iso:std:iso:20022:tech:xsd:camt.054.001.02', :camt054)

--- a/spec/fixtures/053/valid_example_v4.xml
+++ b/spec/fixtures/053/valid_example_v4.xml
@@ -331,6 +331,11 @@
                 </Tp>
               </Rcrd>
             </Chrgs>
+            <RltdPties>
+              <Dbtr>
+                <Nm>Hans Kaufmann</Nm>
+              </Dbtr>
+            </RltdPties>
             <RltdAgts>
               <DbtrAgt>
                 <FinInstnId>

--- a/spec/fixtures/053/valid_example_v8.xml
+++ b/spec/fixtures/053/valid_example_v8.xml
@@ -1,0 +1,365 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.053.001.08"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <BkToCstmrStmt>
+    <GrpHdr>
+      <MsgId>R39B4SA289HMZ6XA</MsgId>
+      <CreDtTm>2023-06-20T18:43:23+02:00</CreDtTm>
+      <MsgRcpt>
+        <Id>
+          <OrgId>
+            <AnyBIC>UBSWCHZHREB</AnyBIC>
+          </OrgId>
+        </Id>
+      </MsgRcpt>
+      <MsgPgntn>
+        <PgNb>1</PgNb>
+        <LastPgInd>true</LastPgInd>
+      </MsgPgntn>
+      <AddtlInf>SPS/2.0</AddtlInf>
+    </GrpHdr>
+    <Stmt>
+      <Id>R30B4SA880HMZ9XA</Id>
+      <ElctrncSeqNb>122</ElctrncSeqNb>
+      <CreDtTm>2023-06-20T18:43:23+02:00</CreDtTm>
+      <FrToDt>
+        <FrDtTm>2023-06-20T00:00:00+02:00</FrDtTm>
+        <ToDtTm>2023-06-20T23:59:59+02:00</ToDtTm>
+      </FrToDt>
+      <Acct>
+        <Id>
+          <IBAN>CH1111111111111111111</IBAN>
+        </Id>
+        <Ccy>CHF</Ccy>
+        <Ownr>
+          <Nm>ACME GmbH</Nm>
+        </Ownr>
+        <Svcr>
+          <FinInstnId>
+            <BICFI>UBSWCHZH80A</BICFI>
+            <Nm>UBS Switzerland AG</Nm>
+            <Othr>
+              <Id>CHE-116.303.292 MWST</Id>
+              <Issr>VAT-ID</Issr>
+            </Othr>
+          </FinInstnId>
+        </Svcr>
+      </Acct>
+      <Bal>
+        <Tp>
+          <CdOrPrtry>
+            <Cd>OPBD</Cd>
+          </CdOrPrtry>
+        </Tp>
+        <Amt Ccy="CHF">82721.95</Amt>
+        <CdtDbtInd>CRDT</CdtDbtInd>
+        <Dt>
+          <Dt>2023-06-20</Dt>
+        </Dt>
+      </Bal>
+      <Bal>
+        <Tp>
+          <CdOrPrtry>
+            <Cd>CLBD</Cd>
+          </CdOrPrtry>
+        </Tp>
+        <Amt Ccy="CHF">84515.25</Amt>
+        <CdtDbtInd>CRDT</CdtDbtInd>
+        <Dt>
+          <Dt>2023-06-20</Dt>
+        </Dt>
+      </Bal>
+      <Bal>
+        <Tp>
+          <CdOrPrtry>
+            <Cd>CLAV</Cd>
+          </CdOrPrtry>
+        </Tp>
+        <Amt Ccy="CHF">83415.25</Amt>
+        <CdtDbtInd>CRDT</CdtDbtInd>
+        <Dt>
+          <Dt>2023-06-20</Dt>
+        </Dt>
+      </Bal>
+      <Ntry>
+        <Amt Ccy="CHF">474.4</Amt>
+        <CdtDbtInd>CRDT</CdtDbtInd>
+        <Sts>
+          <Cd>BOOK</Cd>
+        </Sts>
+        <BookgDt>
+          <Dt>2023-06-20</Dt>
+        </BookgDt>
+        <ValDt>
+          <Dt>2023-06-20</Dt>
+        </ValDt>
+        <AcctSvcrRef>9999171ZC0173078</AcctSvcrRef>
+        <BkTxCd>
+          <Domn>
+            <Cd>PMNT</Cd>
+            <Fmly>
+              <Cd>RCDT</Cd>
+              <SubFmlyCd>AUTT</SubFmlyCd>
+            </Fmly>
+          </Domn>
+          <Prtry>
+            <Cd>Z04</Cd>
+          </Prtry>
+        </BkTxCd>
+        <AmtDtls>
+          <InstdAmt>
+            <Amt Ccy="CHF">474.4</Amt>
+          </InstdAmt>
+        </AmtDtls>
+        <NtryDtls>
+          <TxDtls>
+            <Refs>
+              <AcctSvcrRef>9999181ZC0283079</AcctSvcrRef>
+              <EndToEndId>80000004540000100095</EndToEndId>
+              <UETR>d0826d0f-a005-5e3b-b3dc-54da4ac7f0d0</UETR>
+            </Refs>
+            <Amt Ccy="CHF">474.4</Amt>
+            <CdtDbtInd>CRDT</CdtDbtInd>
+            <AmtDtls>
+              <InstdAmt>
+                <Amt Ccy="CHF">474.4</Amt>
+              </InstdAmt>
+              <TxAmt>
+                <Amt Ccy="CHF">474.4</Amt>
+              </TxAmt>
+            </AmtDtls>
+            <BkTxCd>
+              <Domn>
+                <Cd>PMNT</Cd>
+                <Fmly>
+                  <Cd>RCDT</Cd>
+                  <SubFmlyCd>AUTT</SubFmlyCd>
+                </Fmly>
+              </Domn>
+              <Prtry>
+                <Cd>Z04</Cd>
+              </Prtry>
+            </BkTxCd>
+            <RltdPties>
+              <Dbtr>
+                <Pty>
+                  <Nm>Jon Doe</Nm>
+                  <PstlAdr>
+                    <AdrLine>Hofstrasse 2</AdrLine>
+                    <AdrLine>CH-8000 Zürich</AdrLine>
+                  </PstlAdr>
+                </Pty>
+              </Dbtr>
+            </RltdPties>
+            <RmtInf>
+              <Ustrd>INVOICE R77561</Ustrd>
+            </RmtInf>
+            <AddtlTxInf>Payment</AddtlTxInf>
+          </TxDtls>
+        </NtryDtls>
+        <AddtlNtryInf>Payment</AddtlNtryInf>
+      </Ntry>
+      <Ntry>
+        <NtryRef>CH700033323323241701E</NtryRef>
+        <Amt Ccy="CHF">88.85</Amt>
+        <CdtDbtInd>CRDT</CdtDbtInd>
+        <Sts>
+          <Cd>BOOK</Cd>
+        </Sts>
+        <BookgDt>
+          <Dt>2023-06-20</Dt>
+        </BookgDt>
+        <ValDt>
+          <Dt>2023-06-20</Dt>
+        </ValDt>
+        <AcctSvcrRef>2022172PH0003127</AcctSvcrRef>
+        <BkTxCd>
+          <Domn>
+            <Cd>PMNT</Cd>
+            <Fmly>
+              <Cd>RCDT</Cd>
+              <SubFmlyCd>VCOM</SubFmlyCd>
+            </Fmly>
+          </Domn>
+          <Prtry>
+            <Cd>A90</Cd>
+          </Prtry>
+        </BkTxCd>
+        <NtryDtls>
+          <Btch>
+            <MsgId>1b30f9941c8e459f9b0a7b11137b3720</MsgId>
+            <PmtInfId>8d8075ce49134553a261033714278400</PmtInfId>
+            <NbOfTxs>1</NbOfTxs>
+            <TtlAmt Ccy="CHF">88.85</TtlAmt>
+            <CdtDbtInd>CRDT</CdtDbtInd>
+          </Btch>
+          <TxDtls>
+            <Refs>
+              <AcctSvcrRef>0123171DO5126811</AcctSvcrRef>
+              <EndToEndId>435A9287E088BDB1D97FAABD181C70C8</EndToEndId>
+            </Refs>
+            <Amt Ccy="CHF">88.85</Amt>
+            <CdtDbtInd>CRDT</CdtDbtInd>
+            <AmtDtls>
+              <InstdAmt>
+                <Amt Ccy="CHF">88.85</Amt>
+              </InstdAmt>
+              <TxAmt>
+                <Amt Ccy="CHF">88.85</Amt>
+              </TxAmt>
+            </AmtDtls>
+            <BkTxCd>
+              <Domn>
+                <Cd>PMNT</Cd>
+                <Fmly>
+                  <Cd>RCDT</Cd>
+                  <SubFmlyCd>VCOM</SubFmlyCd>
+                </Fmly>
+              </Domn>
+              <Prtry>
+                <Cd>A90</Cd>
+              </Prtry>
+            </BkTxCd>
+            <RltdPties>
+              <InitgPty>
+                <Pty>
+                  <Nm>Finanz AG</Nm>
+                </Pty>
+              </InitgPty>
+              <Dbtr>
+                <Pty>
+                  <Nm>Finanz AG</Nm>
+                </Pty>
+              </Dbtr>
+            </RltdPties>
+            <RmtInf>
+              <Strd>
+                <CdtrRefInf>
+                  <Tp>
+                    <CdOrPrtry>
+                      <Cd>SCOR</Cd>
+                    </CdOrPrtry>
+                  </Tp>
+                  <Ref>RF38000000000000000000552</Ref>
+                </CdtrRefInf>
+              </Strd>
+            </RmtInf>
+            <AddtlTxInf>Credit Creditor Reference</AddtlTxInf>
+          </TxDtls>
+        </NtryDtls>
+        <AddtlNtryInf>Credit Creditor Reference</AddtlNtryInf>
+      </Ntry>
+      <Ntry>
+        <Amt Ccy="CHF">19.69</Amt>
+        <CdtDbtInd>DBIT</CdtDbtInd>
+        <Sts>
+          <Cd>BOOK</Cd>
+        </Sts>
+        <BookgDt>
+          <Dt>2023-06-20</Dt>
+        </BookgDt>
+        <ValDt>
+          <Dt>2023-06-20</Dt>
+        </ValDt>
+        <AcctSvcrRef>0124571DN6195349</AcctSvcrRef>
+        <BkTxCd>
+          <Domn>
+            <Cd>PMNT</Cd>
+            <Fmly>
+              <Cd>ICDT</Cd>
+              <SubFmlyCd>AUTT</SubFmlyCd>
+            </Fmly>
+          </Domn>
+          <Prtry>
+            <Cd>Z44</Cd>
+          </Prtry>
+        </BkTxCd>
+        <AmtDtls>
+          <InstdAmt>
+            <Amt Ccy="CHF">19.69</Amt>
+          </InstdAmt>
+          <TxAmt>
+            <Amt Ccy="CHF">19.69</Amt>
+          </TxAmt>
+        </AmtDtls>
+        <NtryDtls>
+          <TxDtls>
+            <Refs>
+              <MsgId>01222ABC</MsgId>
+              <AcctSvcrRef>0123171DN6095310</AcctSvcrRef>
+              <PmtInfId>01222ABC-HAF</PmtInfId>
+              <InstrId>373502949-1208481</InstrId>
+              <EndToEndId>1208481</EndToEndId>
+            </Refs>
+            <Amt Ccy="CHF">19.69</Amt>
+            <CdtDbtInd>DBIT</CdtDbtInd>
+            <AmtDtls>
+              <InstdAmt>
+                <Amt Ccy="CHF">19.69</Amt>
+              </InstdAmt>
+              <TxAmt>
+                <Amt Ccy="CHF">19.69</Amt>
+              </TxAmt>
+            </AmtDtls>
+            <BkTxCd>
+              <Domn>
+                <Cd>PMNT</Cd>
+                <Fmly>
+                  <Cd>ICDT</Cd>
+                  <SubFmlyCd>AUTT</SubFmlyCd>
+                </Fmly>
+              </Domn>
+              <Prtry>
+                <Cd>Z44</Cd>
+              </Prtry>
+            </BkTxCd>
+            <RltdPties>
+              <InitgPty>
+                <Pty>
+                  <Nm>ACME GmbH</Nm>
+                </Pty>
+              </InitgPty>
+              <Cdtr>
+                <Pty>
+                  <Nm>DHL Express (Schweiz) AG</Nm>
+                  <PstlAdr>
+                    <Ctry>CH</Ctry>
+                    <AdrLine>Hochstrasse 5</AdrLine>
+                    <AdrLine>4052 Basel</AdrLine>
+                  </PstlAdr>
+                </Pty>
+              </Cdtr>
+              <CdtrAcct>
+                <Id>
+                  <IBAN>CH2222222222222222222</IBAN>
+                </Id>
+              </CdtrAcct>
+            </RltdPties>
+            <RltdAgts>
+              <DbtrAgt>
+                <FinInstnId>
+                  <BICFI>UBSWCHZH80A</BICFI>
+                </FinInstnId>
+              </DbtrAgt>
+            </RltdAgts>
+            <RmtInf>
+              <Strd>
+                <CdtrRefInf>
+                  <Tp>
+                    <CdOrPrtry>
+                      <Prtry>QRR</Prtry>
+                    </CdOrPrtry>
+                  </Tp>
+                  <Ref>000000270148751802165444888</Ref>
+                </CdtrRefInf>
+              </Strd>
+            </RmtInf>
+            <AddtlTxInf>e-banking Order // FILETRANSFER</AddtlTxInf>
+          </TxDtls>
+        </NtryDtls>
+        <AddtlNtryInf>e-banking Order // FILETRANSFER</AddtlNtryInf>
+      </Ntry>
+
+    </Stmt>
+  </BkToCstmrStmt>
+</Document>

--- a/spec/fixtures/053/valid_example_v8.xml
+++ b/spec/fixtures/053/valid_example_v8.xml
@@ -343,11 +343,11 @@
               </CdtrAcct>
             </RltdPties>
             <RltdAgts>
-              <DbtrAgt>
+              <CdtrAgt>
                 <FinInstnId>
                   <BICFI>UBSWCHZH80A</BICFI>
                 </FinInstnId>
-              </DbtrAgt>
+              </CdtrAgt>
             </RltdAgts>
             <RmtInf>
               <Strd>

--- a/spec/fixtures/053/valid_example_v8.xml
+++ b/spec/fixtures/053/valid_example_v8.xml
@@ -151,6 +151,13 @@
                 </Pty>
               </Dbtr>
             </RltdPties>
+            <RltdAgts>
+              <DbtrAgt>
+                <FinInstnId>
+                  <BICFI>UBSWCHZH80A</BICFI>
+                </FinInstnId>
+              </DbtrAgt>
+            </RltdAgts>
             <RmtInf>
               <Ustrd>INVOICE R77561</Ustrd>
             </RmtInf>

--- a/spec/lib/camt_parser/053/statement_spec.rb
+++ b/spec/lib/camt_parser/053/statement_spec.rb
@@ -30,4 +30,25 @@ RSpec.describe CamtParser::Format053::Statement do
 
     specify { expect(ex_ntry.charges).to be_kind_of(CamtParser::Charges)}
   end
+
+  context 'version 8' do
+    let(:camt)          { CamtParser::File.parse('spec/fixtures/053/valid_example_v8.xml') }
+
+    let(:statements)    { camt.statements }
+    let(:ex_stmt)       { camt.statements[0] }
+    let(:ex_ntry)       { ex_stmt.entries[0] }
+    let(:ex_ntry_chrgs) { ex_stmt.entries[0] }
+
+    specify { expect(ex_ntry.charges).to be_kind_of(CamtParser::Charges) }
+    specify { expect(ex_stmt.identification).to eq("R30B4SA880HMZ9XA") }
+    specify { expect(ex_stmt.generation_date).to be_kind_of(Time) }
+    specify { expect(ex_stmt.from_date_time).to eq(Time.parse("2023-06-20 00:00:00 +0200")) }
+    specify { expect(ex_stmt.to_date_time).to eq(Time.parse("2023-06-20 23:59:59 +0200")) }
+    specify { expect(ex_stmt.account).to be_kind_of(CamtParser::Account) }
+    specify { expect(ex_stmt.entries).to be_kind_of(Array) }
+    specify { expect(ex_stmt.electronic_sequence_number).to eq("122") }
+
+    specify { expect(ex_stmt.opening_balance).to be_kind_of(CamtParser::AccountBalance) }
+    specify { expect(ex_stmt.closing_balance).to be_kind_of(CamtParser::AccountBalance) }
+  end
 end

--- a/spec/lib/camt_parser/general/account_spec.rb
+++ b/spec/lib/camt_parser/general/account_spec.rb
@@ -18,4 +18,14 @@ RSpec.describe CamtParser::Account do
     specify { expect(account.other_id).to eq("ABCDE1234") }
     specify { expect(account.account_number).to eq("ABCDE1234") }
   end
+
+  context "version 8" do
+    let(:camt) { CamtParser::File.parse('spec/fixtures/053/valid_example_v8.xml') }
+
+    specify { expect(account.iban).to eq("CH1111111111111111111") }
+    specify { expect(account.account_number).to eq("CH1111111111111111111") }
+    specify { expect(account.bic).to eq("UBSWCHZH80A") }
+    specify { expect(account.bank_name).to eq("UBS Switzerland AG") }
+    specify { expect(account.currency).to eq("CHF") }
+  end
 end

--- a/spec/lib/camt_parser/general/creditor_spec.rb
+++ b/spec/lib/camt_parser/general/creditor_spec.rb
@@ -20,5 +20,6 @@ RSpec.describe CamtParser::Creditor do
     let(:ex_entry)       { entries[2] }
 
     specify { expect(creditor.name).to eq("DHL Express (Schweiz) AG") }
+    specify { expect(creditor.bic).to eq("UBSWCHZH80A") }
   end
 end

--- a/spec/lib/camt_parser/general/creditor_spec.rb
+++ b/spec/lib/camt_parser/general/creditor_spec.rb
@@ -14,4 +14,11 @@ RSpec.describe CamtParser::Creditor do
   specify { expect(creditor.iban).to eq("DE09300606010012345671") }
   specify { expect(creditor.bic).to eq("DAAEDEDDXXX") }
   specify { expect(creditor.bank_name).to eq("Bank") }
+
+  context "version 8" do
+    let(:camt)           { CamtParser::File.parse('spec/fixtures/053/valid_example_v8.xml') }
+    let(:ex_entry)       { entries[2] }
+
+    specify { expect(creditor.name).to eq("DHL Express (Schweiz) AG") }
+  end
 end

--- a/spec/lib/camt_parser/general/debitor_spec.rb
+++ b/spec/lib/camt_parser/general/debitor_spec.rb
@@ -14,4 +14,10 @@ RSpec.describe CamtParser::Debitor do
   specify { expect(debitor.iban).to eq("DE24302201900609832118") }
   specify { expect(debitor.bic).to eq("DAAEDEDDXXX") }
   specify { expect(debitor.bank_name).to eq("") }
+
+
+  context "version 8" do
+    let(:camt)           { CamtParser::File.parse('spec/fixtures/053/valid_example_v8.xml') }
+    specify { expect(debitor.name).to eq("Jon Doe") }
+  end
 end

--- a/spec/lib/camt_parser/general/debitor_spec.rb
+++ b/spec/lib/camt_parser/general/debitor_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe CamtParser::Debitor do
 
   context "version 8" do
     let(:camt)           { CamtParser::File.parse('spec/fixtures/053/valid_example_v8.xml') }
+
     specify { expect(debitor.name).to eq("Jon Doe") }
+    specify { expect(debitor.bic).to eq("UBSWCHZH80A") }
   end
 end

--- a/spec/lib/camt_parser/general/transaction_spec.rb
+++ b/spec/lib/camt_parser/general/transaction_spec.rb
@@ -79,6 +79,38 @@ RSpec.describe CamtParser::Transaction do
       specify { expect(ex_transaction.reason_code).to eq("MD06") }
     end
 
+    specify { expect(ex_transaction.name).to eq("Hans Kaufmann") }
     specify { expect(ex_transaction.creditor_reference).to eq("CreditorReference") }
+  end
+
+  context 'version 8' do
+    let(:camt)       { CamtParser::File.parse('spec/fixtures/053/valid_example_v8.xml') }
+    let(:statements) { camt.statements }
+    let(:ex_stmt)    { statements[0] }
+    let(:entries)  { ex_stmt.entries }
+    let(:ex_entry) { entries[1] }
+    let(:transactions)   { ex_entry.transactions }
+    let(:ex_transaction) { transactions[0] }
+
+    context '#amount' do
+      specify { expect(ex_transaction.amount).to be_kind_of(BigDecimal) }
+      specify { expect(ex_transaction.amount).to eq(BigDecimal('88.85')) }
+      specify { expect(ex_transaction.amount_in_cents).to eq(8885) }
+    end
+
+
+    specify { expect(ex_transaction.name).to eq("Finanz AG") }
+    specify { expect(ex_transaction.creditor_reference).to eq("RF38000000000000000000552") }
+    specify { expect(ex_transaction.swift_code).to eq("A90") }
+    specify { expect(ex_transaction.bank_reference).to eq("0123171DO5126811") }
+    specify { expect(ex_transaction.end_to_end_reference).to eq("435A9287E088BDB1D97FAABD181C70C8") }
+
+    context "#remittance_information" do
+      let(:ex_entry) { entries[0] }
+      let(:transactions)   { ex_entry.transactions }
+      let(:ex_transaction) { transactions[0] }
+
+    specify { expect(ex_transaction.remittance_information).to eq("INVOICE R77561") }
+    end
   end
 end


### PR DESCRIPTION
The debitor and creditor name and bic are currently not correctly parsed for camt.053 version 1.08. This PR fixes this.
I have added a new fixtures file for the new namespace and corresponding tests.
The documentation of the standard can be found here: 
https://www.six-group.com/dam/download/banking-services/standardization/sps/ig-cash-management-v2.0.2-de.pdf