### PR TITLE
Add support for #booking_datetime and #value_datetime

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     builder (3.2.2)
-    diff-lcs (1.2.5)
+    diff-lcs (1.5.0)
     mini_portile2 (2.8.1)
     nokogiri (1.14.3)
       mini_portile2 (~> 2.8.0)

--- a/lib/camt_parser/general/entry.rb
+++ b/lib/camt_parser/general/entry.rb
@@ -28,12 +28,22 @@ module CamtParser
 
     # @return [Date]
     def value_date
-      @value_date ||= Date.parse(xml_data.xpath('ValDt/Dt/text()').text)
+      @value_date ||= ((date = xml_data.xpath('ValDt/Dt/text()').text).empty? ? nil : Date.parse(date))
     end
 
     # @return [Date]
     def booking_date
-      @booking_date ||= Date.parse(xml_data.xpath('BookgDt/Dt/text()').text)
+      @booking_date ||= ((date = xml_data.xpath('BookgDt/Dt/text()').text).empty? ? nil : Date.parse(date))
+    end
+
+    # @return [DateTime]
+    def value_datetime
+      @value_datetime ||= ((datetime = xml_data.xpath('ValDt/DtTm/text()').text).empty? ? nil : DateTime.parse(datetime))
+    end
+
+    # @return [DateTime]
+    def booking_datetime
+      @booking_datetime ||= ((datetime = xml_data.xpath('BookgDt/DtTm/text()').text).empty? ? nil : DateTime.parse(datetime))
     end
 
     # @return [String]
@@ -83,8 +93,8 @@ module CamtParser
     end
     # @return [CamtParser::BatchDetail, nil]
     def batch_detail
-      @batch_detail ||= xml_data.xpath('NtryDtls/Btch').empty? ? nil : CamtParser::BatchDetail.new(xml_data.xpath('NtryDtls/Btch'))
-    end  
+      @batch_detail ||= xml_data.xpath('NtryDtls/Btch').empty? ? nil : CamtParser::BatchDetail.new(@xml_data.xpath('NtryDtls/Btch'))
+    end
 
     private
 
@@ -101,6 +111,5 @@ module CamtParser
 
       xml_data.xpath('NtryDtls/TxDtls').map { |x| Transaction.new(x, debit?, amt, ccy) }
     end
-    
   end
 end

--- a/lib/camt_parser/register.rb
+++ b/lib/camt_parser/register.rb
@@ -8,6 +8,7 @@ CamtParser::Xml.register('urn:iso:std:iso:20022:tech:xsd:camt.052.001.02', :camt
 CamtParser::Xml.register('urn:iso:std:iso:20022:tech:xsd:camt.053.001.02', :camt053)
 CamtParser::Xml.register('urn:iso:std:iso:20022:tech:xsd:camt.053.001.04', :camt053)
 CamtParser::Xml.register('urn:iso:std:iso:20022:tech:xsd:camt.053.001.08', :camt053)
+CamtParser::Xml.register('urn:iso:std:iso:20022:tech:xsd:camt.053.001.10', :camt053)
 
 ## CAMT054
 CamtParser::Xml.register('urn:iso:std:iso:20022:tech:xsd:camt.054.001.02', :camt054)

--- a/spec/fixtures/053/valid_example_with_datetime.xml
+++ b/spec/fixtures/053/valid_example_with_datetime.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:iso:std:iso:20022:tech:xsd:camt.053.001.10">
+    <BkToCstmrStmt>
+        <GrpHdr>
+            <MsgId>1234567-1234567891000</MsgId>
+            <CreDtTm>2023-07-06T10:27:07.213294607Z</CreDtTm>
+        </GrpHdr>
+        <Stmt>
+            <Id>7301750-38631543-1688639227213</Id>
+            <CreDtTm>2023-07-06T10:27:07.213294607Z</CreDtTm>
+            <FrToDt>
+                <FrDtTm>2022-07-07T00:00:00+02:00</FrDtTm>
+                <ToDtTm>2023-07-07T00:00:00+02:00</ToDtTm>
+            </FrToDt>
+            <Acct>
+                <Id>
+                    <Othr>
+                        <Id>11111111</Id>
+                        <SchmeNm>
+                            <Prtry>Wise Account ID</Prtry>
+                        </SchmeNm>
+                        <Issr>Wise Payments Ltd.</Issr>
+                    </Othr>
+                </Id>
+                <Ccy>USD</Ccy>
+                <Ownr>
+                    <Nm>Max Muster</Nm>
+                    <PstlAdr>
+                        <AdrTp>
+                            <Cd>ADDR</Cd>
+                        </AdrTp>
+                            <PstCd>4410</PstCd>
+                        <TwnNm>Liestal</TwnNm>
+                        <AdrLine>Beispielstrasse 10</AdrLine>
+                    </PstlAdr>
+                    <Id>
+                        <PrvtId>
+                            <Othr>
+                                <Id>1111111</Id>
+                                <SchmeNm>
+                                    <Cd>CUST</Cd>
+                                </SchmeNm>
+                            </Othr>
+                        </PrvtId>
+                    </Id>
+                </Ownr>
+                <Svcr>
+                    <FinInstnId>
+                        <Nm>Wise Payments Ltd.</Nm>
+                        <PstlAdr>
+                            <AdrTp>
+                                <Cd>ADDR</Cd>
+                            </AdrTp>
+                            <PstCd>E1 6JJ</PstCd>
+                            <TwnNm>London</TwnNm>
+                            <AdrLine>6th Floor, The Tea Building, 56 Shoreditch High Street</AdrLine>
+                        </PstlAdr>
+                    </FinInstnId>
+                </Svcr>
+            </Acct>
+            <Bal>
+                <Tp>
+                    <CdOrPrtry>
+                        <Cd>CLBD</Cd>
+                    </CdOrPrtry>
+                </Tp>
+                <Amt Ccy="USD">606.80</Amt>
+                <CdtDbtInd>CRDT</CdtDbtInd>
+                <Dt>
+                    <DtTm>2023-07-07T00:00:00+02:00</DtTm>
+                </Dt>
+            </Bal>
+            <TxsSummry>
+                <TtlNtries>
+                    <NbOfNtries>14</NbOfNtries>
+                    <Sum>606.80</Sum>
+                    <TtlNetNtry>
+                        <Amt>606.80</Amt>
+                        <CdtDbtInd>CRDT</CdtDbtInd>
+                    </TtlNetNtry>
+                </TtlNtries>
+                <TtlCdtNtries>
+                    <NbOfNtries>4</NbOfNtries>
+                    <Sum>1115.92</Sum>
+                </TtlCdtNtries>
+                <TtlDbtNtries>
+                    <NbOfNtries>10</NbOfNtries>
+                    <Sum>-509.12</Sum>
+                </TtlDbtNtries>
+            </TxsSummry>
+            <Ntry>
+                <NtryRef>Test Buchung</NtryRef>
+                <Amt Ccy="USD">195.86</Amt>
+                <CdtDbtInd>CRDT</CdtDbtInd>
+                <Sts>
+                    <Cd>BOOK</Cd>
+                </Sts>
+                <BookgDt>
+                    <DtTm>2023-06-21T12:35:33.115965+00:00</DtTm>
+                </BookgDt>
+                <BkTxCd>
+                    <Prtry>
+                        <Cd>TRANSFER-123456789</Cd>
+                    </Prtry>
+                </BkTxCd>
+                <Chrgs>
+                    <TtlChrgsAndTaxAmt Ccy="USD">4.14</TtlChrgsAndTaxAmt>
+                </Chrgs>
+            </Ntry>
+        </Stmt>
+    </BkToCstmrStmt>
+</Document>

--- a/spec/lib/camt_parser/general/entry_spec.rb
+++ b/spec/lib/camt_parser/general/entry_spec.rb
@@ -29,4 +29,11 @@ RSpec.describe CamtParser::Entry do
   specify { expect(ex_entry.transactions).to all(be_kind_of(CamtParser::Transaction)) }
   specify { expect(ex_entry.bank_reference).to eq('2013122710583450000') }
   specify { expect(ex_entry.xml_data).to_not be_nil }
+
+  context 'datetime' do
+    let(:camt) { CamtParser::File.parse('spec/fixtures/053/valid_example_with_datetime.xml') }
+    specify { expect(ex_entry.booking_datetime).to be_kind_of(DateTime) }
+    specify { expect(ex_entry.booking_datetime).to eq(DateTime.new(2023, 06, 21, 12, 35, 33.115965)) }
+    specify { expect(ex_entry.value_datetime).to eq(nil) }
+  end
 end


### PR DESCRIPTION
I just stumbled upon a camt.053 statement that had a booking datetime value instead of a booking date.

This PR adds support for `Entry#booking_datetime` and `Entry#value_datetime` while also returning `nil` for `Entry#booking_date` and `Entry#value_date` if these attributes are empty. This makes it possible to simply check for `nil` when otherwise `Date.parse(nil)` would have thrown an `ArgumentError`.

For example:

```
booking_date = entry.date || entry.datetime&.to_date
```