### PR TITLE
CI: Configure dependabot to update GH Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
The GH Actions that can be updated via their tag, like `@v2`, will be targeted by this change.