### PR TITLE
Update entry.rb to extract NtryRef

### DIFF
--- a/lib/camt_parser/general/entry.rb
+++ b/lib/camt_parser/general/entry.rb
@@ -96,6 +96,10 @@ module CamtParser
       @batch_detail ||= xml_data.xpath('NtryDtls/Btch').empty? ? nil : CamtParser::BatchDetail.new(@xml_data.xpath('NtryDtls/Btch'))
     end
 
+    def ntry_ref
+      @ntry_ref ||= xml_data.at_xpath('.//NtryRef').text
+    end
+
     private
 
     def parse_transactions

--- a/spec/camt_parser_entry_spec.rb
+++ b/spec/camt_parser_entry_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rspec'
+require 'date'
+require_relative '../lib/camt_parser/general/entry'
+
+RSpec.describe CamtParser::Entry do
+  let(:xml_data) do
+    Nokogiri::XML(<<~XML)
+      <Ntry>
+        <NtryRef>20231004460032/0000002</NtryRef>
+        <Amt Ccy="EUR">3600.00</Amt>
+        <CdtDbtInd>DBIT</CdtDbtInd>
+        <RvslInd>false</RvslInd>
+        <Sts>BOOK</Sts>
+        <BookgDt>
+          <Dt>2023-10-04</Dt>
+        </BookgDt>
+        <ValDt>
+          <Dt>2023-10-04</Dt>
+        </ValDt>
+      </Ntry>
+    XML
+  end
+
+  subject(:entry) { described_class.new(xml_data) }
+
+  describe '#ntry_ref' do
+    it 'returns the correct NtryRef value' do
+      expect(entry.ntry_ref).to eq('20231004460032/0000002')
+    end
+  end
+end


### PR DESCRIPTION
- Added  the `ntry_ref` method in `entry.rb` to ensure correct extraction of NtryRef.
- Added an RSpec test (`spec/camt_parser_entry_spec.rb`) to validate the new behavior.