### PR TITLE
add currency details to transaction.rb

### DIFF
--- a/lib/camt_parser/general/transaction.rb
+++ b/lib/camt_parser/general/transaction.rb
@@ -80,6 +80,18 @@ module CamtParser
       @reference ||= xml_data.xpath('Refs/InstrId/text()').text
     end
 
+    def original_currency_amount # May be missing
+      @original_currency_amount ||= CamtParser::Misc.to_amount(parse_original_currency_amount)
+    end
+
+    def original_currency # May be missing
+      @original_currency ||= xml_data.xpath('AmtDtls/InstdAmt/Amt/@Ccy').text
+    end
+
+    def exchange_rate # May be missing
+      @exchange_rate ||= xml_data.xpath('AmtDtls/TxAmt/CcyXchg/XchgRate/text()').text
+    end
+
     def bank_reference # May be missing
       @bank_reference ||= xml_data.xpath('Refs/AcctSvcrRef/text()').text
     end
@@ -117,6 +129,10 @@ module CamtParser
     end
 
     private
+
+    def parse_original_currency_amount
+      xml_data.xpath('AmtDtls/InstdAmt/Amt/text()').text
+    end
 
     def parse_amount
       if xml_data.xpath('Amt').any?

--- a/spec/fixtures/053/valid_example_v8.xml
+++ b/spec/fixtures/053/valid_example_v8.xml
@@ -257,7 +257,7 @@
         <AddtlNtryInf>Credit Creditor Reference</AddtlNtryInf>
       </Ntry>
       <Ntry>
-        <Amt Ccy="CHF">19.69</Amt>
+        <Amt Ccy="EUR">20.97</Amt>
         <CdtDbtInd>DBIT</CdtDbtInd>
         <Sts>
           <Cd>BOOK</Cd>
@@ -286,7 +286,11 @@
             <Amt Ccy="CHF">19.69</Amt>
           </InstdAmt>
           <TxAmt>
-            <Amt Ccy="CHF">19.69</Amt>
+            <Amt Ccy="EUR">20.97</Amt>
+            <CcyXchg>
+              <SrcCcy>CHF</SrcCcy>
+              <XchgRate>0.9433</XchgRate>
+            </CcyXchg>
           </TxAmt>
         </AmtDtls>
         <NtryDtls>
@@ -298,14 +302,18 @@
               <InstrId>373502949-1208481</InstrId>
               <EndToEndId>1208481</EndToEndId>
             </Refs>
-            <Amt Ccy="CHF">19.69</Amt>
+            <Amt Ccy="EUR">20.97</Amt>
             <CdtDbtInd>DBIT</CdtDbtInd>
             <AmtDtls>
               <InstdAmt>
                 <Amt Ccy="CHF">19.69</Amt>
               </InstdAmt>
               <TxAmt>
-                <Amt Ccy="CHF">19.69</Amt>
+                <Amt Ccy="EUR">20.97</Amt>
+                <CcyXchg>
+                  <SrcCcy>CHF</SrcCcy>
+                  <XchgRate>0.9433</XchgRate>
+                </CcyXchg>
               </TxAmt>
             </AmtDtls>
             <BkTxCd>

--- a/spec/lib/camt_parser/general/transaction_spec.rb
+++ b/spec/lib/camt_parser/general/transaction_spec.rb
@@ -100,6 +100,26 @@ RSpec.describe CamtParser::Transaction do
       specify { expect(ex_transaction.amount_in_cents).to eq(8885) }
     end
 
+    context 'transaction with different currency' do
+      let(:ex_transaction) { transactions[0] }
+      let(:ex_entry) { entries[2] }
+
+      context '#amount' do
+        specify { expect(ex_transaction.amount).to be_kind_of(BigDecimal) }
+        specify { expect(ex_transaction.amount).to eq(BigDecimal('20.97')) }
+        specify { expect(ex_transaction.amount_in_cents).to eq(2097) }
+      end
+
+      context '#original_currency_amount' do
+        specify { expect(ex_transaction.original_currency_amount).to be_kind_of(BigDecimal) }
+        specify { expect(ex_transaction.original_currency_amount).to eq(BigDecimal('19.69')) }
+      end
+
+      specify { expect(ex_transaction.currency).to eq('EUR') }
+      specify { expect(ex_transaction.original_currency).to eq('CHF') }
+      specify { expect(ex_transaction.exchange_rate).to eq('0.9433') }
+    end
+
 
     specify { expect(ex_transaction.name).to eq("Finanz AG") }
     specify { expect(ex_transaction.creditor_reference).to eq("RF38000000000000000000552") }


### PR DESCRIPTION
Hello

We need this for handling original currency, original currency amount and exchange rate.
Thanks for considering my PR.

You can find the definition in the XSD.
<img width="826" alt="Screenshot 2025-01-13 at 09 45 41" src="https://github.com/user-attachments/assets/b53ac809-958c-4fa7-b02f-903b66934d17" />
<img width="836" alt="Screenshot 2025-01-13 at 09 46 26" src="https://github.com/user-attachments/assets/e07bc8b7-88b8-4e19-b617-6a7dc8ef53f2" />

Thank you  in advance